### PR TITLE
feat(worktree-management): include main worktree in all listings and selector

### DIFF
--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -5,8 +5,23 @@ import (
 	"github.com/provenimpact/wt/internal/repo"
 )
 
-// completeWorktreeBranches returns existing worktree branch names for tab completion.
+// completeWorktreeBranches returns all existing worktree branch names for tab completion,
+// including the main worktree branch. Used by wt switch.
 func completeWorktreeBranches() []string {
+	worktrees, err := git.ListWorktrees()
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, wt := range worktrees {
+		names = append(names, wt.Branch)
+	}
+	return names
+}
+
+// completeLinkedWorktreeBranches returns linked (non-main) worktree branch names for tab completion.
+// Used by wt remove — the main worktree should not be removable.
+func completeLinkedWorktreeBranches() []string {
 	info, err := repo.Resolve()
 	if err != nil {
 		return nil
@@ -22,10 +37,4 @@ func completeWorktreeBranches() []string {
 		}
 	}
 	return names
-}
-
-// completeLinkedWorktreeBranches returns linked (non-main) worktree branch names for tab completion.
-func completeLinkedWorktreeBranches() []string {
-	// Same as completeWorktreeBranches — both exclude the main worktree.
-	return completeWorktreeBranches()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,21 +41,24 @@ func runSelector(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Filter to only linked worktrees (not the main one)
+	// Build entry list including main worktree
 	var entries []tui.Entry
+	hasLinked := false
 	for _, wt := range worktrees {
-		if wt.Path == info.MainWorktree {
-			continue
+		isMain := wt.Path == info.MainWorktree
+		if !isMain {
+			hasLinked = true
 		}
 		rel, _ := filepath.Rel(filepath.Dir(info.MainWorktree), wt.Path)
 		entries = append(entries, tui.Entry{
 			Branch: wt.Branch,
 			Path:   wt.Path,
 			Rel:    rel,
+			IsMain: isMain,
 		})
 	}
 
-	if len(entries) == 0 {
+	if !hasLinked {
 		fmt.Fprintln(os.Stderr, "No worktrees found. Create one with: wt create <branch>")
 		return nil
 	}

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/provenimpact/wt/internal/git"
 	"github.com/provenimpact/wt/internal/names"
-	"github.com/provenimpact/wt/internal/repo"
 	"github.com/spf13/cobra"
 )
 
@@ -32,11 +31,6 @@ func init() {
 func runSwitch(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
-	info, err := repo.Resolve()
-	if err != nil {
-		return err
-	}
-
 	worktrees, err := git.ListWorktrees()
 	if err != nil {
 		return err
@@ -50,12 +44,9 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Not found -- show available worktrees
+	// Not found -- show all available worktrees including main
 	fmt.Fprintf(os.Stderr, "Worktree %q not found. Available worktrees:\n", name)
 	for _, wt := range worktrees {
-		if wt.Path == info.MainWorktree {
-			continue
-		}
 		fmt.Fprintf(os.Stderr, "  %s\n", wt.Branch)
 	}
 	return fmt.Errorf("worktree %q not found", name)

--- a/docs/features/worktree-management/design.adoc
+++ b/docs/features/worktree-management/design.adoc
@@ -1,9 +1,9 @@
 = Design: Worktree Management
-:version: 2.0.1
+:version: 2.1.0
 :status: Current
-:source-stories-version: 1.1.0
-:source-spec-version: 1.1.0
-:last-updated: 2026-02-26
+:source-stories-version: 1.2.0
+:source-spec-version: 1.2.0
+:last-updated: 2026-02-27
 :feature: worktree-management
 :toc:
 
@@ -68,11 +68,11 @@ flowchart TD
 
 Responsibility: Parse CLI arguments and flags, delegate to core modules, format output. Commands that accept branch/worktree name arguments provide `ValidArgsFunction` callbacks for shell tab-completion.
 
-* `root.go` -- Root command. When invoked with no subcommand, runs the interactive worktree selector.
+* `root.go` -- Root command. When invoked with no subcommand, runs the interactive worktree selector. The selector includes the main worktree (with `IsMain: true` on its `tui.Entry`) alongside all linked worktrees. If only the main worktree exists and no linked worktrees have been created, displays a "no worktrees" message instead.
 * `create.go` -- `wt create [branch] [--base <ref>] [--local] [--remote]` subcommand. With a branch argument, creates directly. Without arguments, launches the interactive branch selector. `--base` specifies a starting point for new branches. `--local` / `--remote` filter the interactive branch list. Provides `ValidArgsFunction` that suggests local + remote branches, excluding branches that already have worktrees.
 * `remove.go` -- `wt remove [name] [--force]` subcommand. Provides `ValidArgsFunction` that suggests linked worktree branch names.
-* `list.go` -- `wt list` subcommand.
-* `switch.go` -- `wt switch <name>` subcommand. Provides `ValidArgsFunction` that suggests existing worktree branch names.
+* `list.go` -- `wt list` subcommand. Always displays the full worktree table including the main worktree (marked with `*`). If only the main worktree exists and no linked worktrees have been created, displays a "no additional worktrees" message.
+* `switch.go` -- `wt switch <name>` subcommand. Matches against all worktrees including the main worktree. Provides `ValidArgsFunction` that suggests all existing worktree branch names including the main worktree branch. Error hint when worktree not found lists all worktrees including main.
 * `status.go` -- `wt status` subcommand.
 * `init.go` -- `wt init <shell>` subcommand.
 * `completion.go` -- `wt completion <shell>` subcommand. Outputs shell-specific completion scripts using Cobra's built-in `GenBashCompletionV2()`, `GenZshCompletion()`, `GenFishCompletion()`. Supports `bash`, `zsh`, and `fish`.
@@ -114,12 +114,13 @@ Responsibility: Display interactive fuzzy-search lists using bubbletea.
 
 ==== Worktree Selector (`selector.go`)
 
-The existing worktree selector:
+The worktree selector:
 
-* Receives a list of worktree entries (branch name, path, relative path).
+* Receives a list of worktree entries (branch name, path, relative path, `IsMain` flag).
+* The `Entry` struct has an `IsMain bool` field. When `IsMain` is true, the entry is rendered with a visually distinct style (dimmed foreground color via lipgloss) to differentiate it from linked worktrees (WT-052). The main worktree is still fully selectable -- the distinct style is for visual identification only, not to disable selection.
 * Renders a filterable list with fuzzy matching on branch name.
 * Returns the selected worktree's path, or empty string if cancelled (Escape/Ctrl-C).
-* Reused by the root command (WT-001) and `wt remove` with no args (WT-013).
+* Reused by the root command (WT-001) and `wt remove` with no args (WT-013). When used for `wt remove`, the main worktree entry is excluded from the entry list by the caller (WT-055).
 
 ==== Branch Selector (`branch_selector.go`)
 
@@ -309,11 +310,12 @@ sequenceDiagram
     Git-->>WT: /path/to/.git
     WT->>WT: Resolve main repo + worktrees dir
     WT->>Git: git worktree list --porcelain
-    Git-->>WT: Worktree list
-    alt No worktrees
+    Git-->>WT: Worktree list (including main)
+    alt Only main worktree (no linked worktrees)
         WT-->>Shell: (stderr) No worktrees found. Use 'wt create <branch>'
-    else Has worktrees
-        WT->>TUI: Display selector
+    else Has linked worktrees
+        WT->>WT: Build entry list (main + linked, main marked IsMain)
+        WT->>TUI: Display selector (main in distinct style)
         TUI-->>User: Interactive fuzzy list
         alt User selects worktree
             User->>TUI: Select entry
@@ -391,9 +393,10 @@ sequenceDiagram
 
 Components:: `cmd/root.go`, `internal/tui`, `internal/repo`, `internal/git`
 Criteria::
-* Interactive fuzzy selector on no-arg invocation → Root command invokes TUI selector with worktree list (WT-001, WT-002)
-* Selection outputs cd instruction → Binary writes `__wt_cd:<path>` to stdout (WT-003)
-* No worktrees message → Checked before TUI launch, message written to stderr (WT-004)
+* Interactive fuzzy selector on no-arg invocation, including main worktree → Root command builds entry list from all worktrees (main + linked), sets `IsMain: true` on the main entry, and invokes TUI selector (WT-001, WT-002)
+* Main worktree rendered with distinct style → TUI selector checks `Entry.IsMain` and applies dimmed foreground style via lipgloss (WT-052)
+* Selection outputs cd instruction → Binary writes `__wt_cd:<path>` to stdout, works for both main and linked worktrees (WT-003, WT-053)
+* No linked worktrees message → If only the main worktree exists, message written to stderr suggesting `wt create` (WT-004)
 * Cancel exits silently → TUI returns empty on Escape, binary exits with no stdout (WT-005)
 
 === US-002: Create Worktree
@@ -420,15 +423,15 @@ Criteria::
 
 Components:: `cmd/list.go`, `internal/repo`, `internal/git`
 Criteria::
-* List all worktrees → Calls `git.ListWorktrees()`, formats table to stderr (WT-018)
-* No additional worktrees message → Filter out main, check if empty (WT-019)
+* List all worktrees including main → Calls `git.ListWorktrees()`, formats table to stderr. The main worktree is always included and marked with `*` in the MAIN column (WT-018)
+* No additional worktrees message → If only the main worktree exists (no linked worktrees), display "No additional worktrees" message to stderr suggesting `wt create` (WT-019)
 
 === US-005: Switch to Worktree
 
 Components:: `cmd/switch.go`, `internal/repo`, `internal/git`
 Criteria::
-* Switch outputs cd instruction → Find worktree by name, write `__wt_cd:<path>` to stdout (WT-020)
-* Not found error with list → Error to stderr, list available worktrees (WT-021)
+* Switch outputs cd instruction → Find worktree by name (searches all worktrees including main), write `__wt_cd:<path>` to stdout (WT-020, WT-054)
+* Not found error with list → Error to stderr, list all available worktrees including the main worktree (WT-021)
 
 === US-006: Worktree Status Overview
 
@@ -480,8 +483,8 @@ Criteria::
 Components:: `cmd/create.go`, `cmd/switch.go`, `cmd/remove.go`, `cmd/completion.go`, `internal/git`
 Criteria::
 * Tab completion for create → `ValidArgsFunction` on `createCmd` calls `git.ListLocalBranches()` + `git.ListRemoteBranches()`, filters out branches that have worktrees, returns with `cobra.ShellCompDirectiveNoFileComp` (WT-043)
-* Tab completion for switch → `ValidArgsFunction` on `switchCmd` calls `git.ListWorktrees()`, returns linked worktree branch names (WT-044)
-* Tab completion for remove → `ValidArgsFunction` on `removeCmd` calls `git.ListWorktrees()`, returns linked worktree branch names (WT-045)
+* Tab completion for switch → `ValidArgsFunction` on `switchCmd` calls `completeWorktreeBranches()` which returns all worktree branch names including the main worktree branch (WT-044)
+* Tab completion for remove → `ValidArgsFunction` on `removeCmd` calls `completeLinkedWorktreeBranches()` which returns only linked (non-main) worktree branch names (WT-045, WT-055)
 * Completion command → `cmd/completion.go` uses Cobra's built-in `rootCmd.GenBashCompletionV2()`, `GenZshCompletion()`, `GenFishCompletion()` to output scripts (WT-046)
 * Error on unsupported shell → `completion.go` validates the shell argument and returns an error listing supported shells (WT-047)
 
@@ -493,6 +496,16 @@ Criteria::
 * Sort by descending score → Both selectors sort `filtered` entries by `Match.Score` descending after scoring (WT-049)
 * Highlight matched characters → Selectors use `Match.Positions` to apply lipgloss highlight style to matched characters in the rendered branch name (WT-050)
 * No scoring when filter is empty → When `textInput.Value() == ""`, entries displayed in original order without calling `fuzzy.Score()` (WT-051)
+
+=== US-013: Main Worktree Visibility
+
+Components:: `cmd/root.go`, `cmd/list.go`, `cmd/switch.go`, `cmd/completions.go`, `internal/tui/selector.go`
+Criteria::
+* Main worktree in all listings → `cmd/root.go` includes main worktree in selector entries; `cmd/list.go` always includes main in table; `cmd/switch.go` includes main in error hint; `cmd/completions.go` `completeWorktreeBranches()` includes main branch (WT-001, WT-018, WT-021, WT-044)
+* Visually distinct in selector → `tui.Entry.IsMain` flag drives dimmed lipgloss style in `selector.go` View() (WT-052)
+* Main worktree marked in list → `cmd/list.go` marks main with `*` in MAIN column (WT-018)
+* Selecting main outputs cd → Same `__wt_cd:` mechanism works for main worktree path (WT-053)
+* Exclude main from remove → `cmd/remove.go` filters main from interactive selector; `completeLinkedWorktreeBranches()` excludes main (WT-055)
 
 == Project Structure
 

--- a/docs/features/worktree-management/spec.adoc
+++ b/docs/features/worktree-management/spec.adoc
@@ -1,17 +1,17 @@
 = Specification: Worktree Management
-:version: 1.1.0
-:source-stories-version: 1.1.0
-:last-updated: 2026-02-26
+:version: 1.2.0
+:source-stories-version: 1.2.0
+:last-updated: 2026-02-27
 :feature: worktree-management
 :prefix: WT
 :toc:
 
 == WT-001
-When the user invokes `wt` with no arguments, the system shall display an interactive fuzzy-search selector listing all existing worktrees for the current repository.
+When the user invokes `wt` with no arguments, the system shall display an interactive fuzzy-search selector listing all existing worktrees for the current repository, including the main worktree.
 
 Type:: Event-driven
 Source:: US-001: Criterion 1
-Verification:: Run `wt` with no arguments in a repository that has worktrees. Confirm an interactive fuzzy-search selector appears listing all worktrees.
+Verification:: Run `wt` with no arguments in a repository that has worktrees. Confirm an interactive fuzzy-search selector appears listing all worktrees, including the main worktree.
 
 == WT-002
 The system shall display each worktree entry in the selector with its branch name and relative path.
@@ -24,21 +24,21 @@ Verification:: Run `wt` with no arguments. Confirm each entry shows the branch n
 When the user selects a worktree from the interactive selector, the system shall output a directory-change instruction targeting the selected worktree directory.
 
 Type:: Event-driven
-Source:: US-001: Criterion 3
+Source:: US-001: Criterion 4
 Verification:: Run `wt`, select a worktree. Confirm the output is a valid directory-change instruction pointing to the selected worktree.
 
 == WT-004
-If no worktrees exist for the current repository, then the system shall display a message indicating no worktrees are available and suggest creating one.
+If only the main worktree exists and no linked worktrees have been created, then the system shall display a message indicating no worktrees are available and suggest creating one.
 
 Type:: Unwanted behavior
-Source:: US-001: Criterion 4
-Verification:: Run `wt` in a repository with no worktrees. Confirm a helpful message is displayed suggesting the create command.
+Source:: US-001: Criterion 5
+Verification:: Run `wt` in a repository with only the main worktree and no linked worktrees. Confirm a helpful message is displayed suggesting the create command.
 
 == WT-005
 When the user cancels the interactive selector, the system shall exit without producing output.
 
 Type:: Event-driven
-Source:: US-001: Criterion 5
+Source:: US-001: Criterion 6
 Verification:: Run `wt`, press Escape. Confirm the system exits silently with no output.
 
 == WT-006
@@ -126,18 +126,18 @@ Source:: US-003: Criterion 5
 Verification:: Remove an existing worktree. Confirm a success message is displayed.
 
 == WT-018
-When the user invokes `wt list`, the system shall display all worktrees for the current repository with branch name, path, and main worktree indicator.
+When the user invokes `wt list`, the system shall display all worktrees for the current repository, including the main worktree, with branch name, path, and main worktree indicator.
 
 Type:: Event-driven
 Source:: US-004: Criterion 1, US-004: Criterion 2
-Verification:: Run `wt list` in a repository with multiple worktrees. Confirm all worktrees are listed with branch, path, and main indicator.
+Verification:: Run `wt list` in a repository with multiple worktrees. Confirm all worktrees are listed with branch, path, and main indicator. Confirm the main worktree is included with a `*` marker.
 
 == WT-019
-If no worktrees exist beyond the main worktree, then the system shall display a message indicating no additional worktrees exist.
+If only the main worktree exists and no linked worktrees have been created, then the system shall display a message indicating no additional worktrees exist and suggest the `wt create` command.
 
 Type:: Unwanted behavior
 Source:: US-004: Criterion 3
-Verification:: Run `wt list` with only the main worktree. Confirm a message indicates no additional worktrees.
+Verification:: Run `wt list` with only the main worktree. Confirm a message indicates no additional worktrees and suggests creating one.
 
 == WT-020
 When the user invokes `wt switch <name>`, the system shall output a directory-change instruction targeting the specified worktree directory.
@@ -147,11 +147,11 @@ Source:: US-005: Criterion 1
 Verification:: Run `wt switch feature-x` for an existing worktree. Confirm the output is a directory-change instruction to that worktree.
 
 == WT-021
-If the specified worktree does not exist when invoking `wt switch`, then the system shall display an error message and list available worktrees.
+If the specified worktree does not exist when invoking `wt switch`, then the system shall display an error message and list all available worktrees, including the main worktree.
 
 Type:: Unwanted behavior
-Source:: US-005: Criterion 2
-Verification:: Run `wt switch nonexistent`. Confirm an error is displayed along with a list of available worktrees.
+Source:: US-005: Criterion 3
+Verification:: Run `wt switch nonexistent`. Confirm an error is displayed along with a list of all available worktrees, including the main worktree.
 
 == WT-022
 When the user invokes `wt status`, the system shall display a summary of all worktrees including branch name, clean/dirty state, and ahead/behind remote counts.
@@ -308,11 +308,11 @@ Source:: US-011: Criterion 1
 Verification:: Source the completion script. Type `wt create ` and press Tab. Confirm branch names are suggested, and branches with existing worktrees are excluded.
 
 == WT-044
-When the user presses Tab after `wt switch`, the system shall suggest existing worktree branch names.
+When the user presses Tab after `wt switch`, the system shall suggest all existing worktree branch names, including the main worktree branch.
 
 Type:: Event-driven
 Source:: US-011: Criterion 2
-Verification:: Source the completion script. Type `wt switch ` and press Tab. Confirm existing worktree branch names are suggested.
+Verification:: Source the completion script. Type `wt switch ` and press Tab. Confirm all existing worktree branch names are suggested, including the main worktree branch.
 
 == WT-045
 When the user presses Tab after `wt remove`, the system shall suggest existing linked worktree branch names.
@@ -363,6 +363,34 @@ Type:: Event-driven
 Source:: US-012: Criterion 5
 Verification:: Open the interactive selector. Without typing any filter text, confirm all entries are displayed in their default order.
 
+== WT-052
+While the main worktree entry is displayed in the interactive selector, the system shall render it with a visually distinct style to differentiate it from linked worktrees.
+
+Type:: State-driven
+Source:: US-001: Criterion 3, US-013: Criterion 2
+Verification:: Run `wt` with no arguments in a repository with linked worktrees. Confirm the main worktree entry is rendered with a different visual style than linked worktree entries.
+
+== WT-053
+When the user selects the main worktree from the interactive selector, the system shall output a directory-change instruction targeting the main worktree directory.
+
+Type:: Event-driven
+Source:: US-013: Criterion 4
+Verification:: Run `wt`, select the main worktree entry. Confirm the output is a valid directory-change instruction pointing to the main repository directory.
+
+== WT-054
+The system shall support switching to the main worktree by its branch name via `wt switch`.
+
+Type:: Ubiquitous
+Source:: US-005: Criterion 2
+Verification:: Run `wt switch main` (where `main` is the main worktree branch). Confirm the output is a directory-change instruction targeting the main repository directory.
+
+== WT-055
+When the user invokes `wt remove` interactively or via tab completion, the system shall exclude the main worktree from the available choices.
+
+Type:: Event-driven
+Source:: US-013: Criterion 5
+Verification:: Run `wt remove` with no arguments. Confirm the interactive selector does not include the main worktree. Source the completion script, type `wt remove ` and press Tab. Confirm the main worktree branch is not suggested.
+
 == Traceability
 
 [cols="1,2,2", options="header"]
@@ -370,7 +398,7 @@ Verification:: Open the interactive selector. Without typing any filter text, co
 | Requirement ID | Requirement Summary | Source
 
 | WT-001
-| Interactive fuzzy selector on no-arg invocation
+| Interactive fuzzy selector on no-arg invocation (including main worktree)
 | US-001: Criterion 1
 
 | WT-002
@@ -379,15 +407,15 @@ Verification:: Open the interactive selector. Without typing any filter text, co
 
 | WT-003
 | Selection outputs directory-change instruction
-| US-001: Criterion 3
+| US-001: Criterion 4
 
 | WT-004
-| No worktrees message with suggestion
-| US-001: Criterion 4
+| No linked worktrees message with suggestion
+| US-001: Criterion 5
 
 | WT-005
 | Cancel exits silently
-| US-001: Criterion 5
+| US-001: Criterion 6
 
 | WT-006
 | Create worktree command
@@ -438,11 +466,11 @@ Verification:: Open the interactive selector. Without typing any filter text, co
 | US-003: Criterion 5
 
 | WT-018
-| List worktrees with details
+| List all worktrees including main with details
 | US-004: Criterion 1, US-004: Criterion 2
 
 | WT-019
-| No additional worktrees message
+| No additional worktrees message with suggestion
 | US-004: Criterion 3
 
 | WT-020
@@ -450,8 +478,8 @@ Verification:: Open the interactive selector. Without typing any filter text, co
 | US-005: Criterion 1
 
 | WT-021
-| Switch error with available worktrees
-| US-005: Criterion 2
+| Switch error lists all worktrees including main
+| US-005: Criterion 3
 
 | WT-022
 | Status summary with branch/dirty/remote
@@ -542,7 +570,7 @@ Verification:: Open the interactive selector. Without typing any filter text, co
 | US-011: Criterion 1
 
 | WT-044
-| Tab completion for switch suggests worktrees
+| Tab completion for switch suggests all worktrees including main
 | US-011: Criterion 2
 
 | WT-045
@@ -572,4 +600,20 @@ Verification:: Open the interactive selector. Without typing any filter text, co
 | WT-051
 | No scoring when filter is empty
 | US-012: Criterion 5
+
+| WT-052
+| Main worktree visually distinct in selector
+| US-001: Criterion 3, US-013: Criterion 2
+
+| WT-053
+| Selecting main worktree outputs directory-change instruction
+| US-013: Criterion 4
+
+| WT-054
+| Switch to main worktree by branch name
+| US-005: Criterion 2
+
+| WT-055
+| Exclude main worktree from remove choices
+| US-013: Criterion 5
 |===

--- a/docs/features/worktree-management/tasks.adoc
+++ b/docs/features/worktree-management/tasks.adoc
@@ -1,177 +1,59 @@
 = Implementation Tasks: Worktree Management
-:version: 2.0.0
+:version: 3.0.0
 :status: Implemented
-:source-design-version: 2.0.0
-:source-stories-version: 1.1.0
-:source-spec-version: 1.1.0
-:last-updated: 2026-02-26
+:source-design-version: 2.1.0
+:source-stories-version: 1.2.0
+:source-spec-version: 1.2.0
+:last-updated: 2026-02-27
 :feature: worktree-management
 :toc:
 
 == Overview
 
-Implements the `wt` CLI tool for git worktree management. 7 phases, 19 tasks. Phases 1–4 (TASK-001 through TASK-011) are complete from the initial implementation. Phases 5–7 (TASK-012 through TASK-019) implement the new features: branch name sanitization, fuzzy scoring, interactive branch selection, and shell completion.
+Implements main worktree visibility across all worktree listings and the interactive selector (issue #9). 2 phases, 5 tasks. Phase 1 modifies the TUI entry model and selector rendering. Phase 2 updates the command layer across 4 files.
 
-== Phase 1: Foundation
+== Phase 1: TUI Model Update
 
-Set up Go project, dependencies, and core modules that all commands depend on.
+Add `IsMain` field to the TUI entry struct and update the selector to render main worktree entries with a distinct visual style.
 
-* [x] TASK-001: Initialize Go module and install dependencies [sequential]
-+
-Components:: Project root
-Stories:: All
-Specs:: All
-Description:: Run `go mod init`, add cobra, bubbletea, bubbles, lipgloss. Create `main.go` entry point with cobra root command. Set up project directory structure (`cmd/`, `internal/repo/`, `internal/git/`, `internal/tui/`, `internal/shell/`).
-
-* [x] TASK-002: Implement repository resolution module [sequential]
-+
-Components:: `internal/repo/repo.go`
-Stories:: US-007
-Specs:: WT-007, WT-024, WT-025
-Description:: Implement `Resolve()` to find the main repository root using `git rev-parse --git-common-dir`. Implement `WorktreesDir()` to compute `<parent>/<name>-worktrees/`. Implement `EnsureWorktreesDir()` to create the directory if it does not exist. Must work when invoked from main repo or any worktree.
-
-* [x] TASK-003: Implement git operations module [sequential]
-+
-Components:: `internal/git/git.go`
-Stories:: US-002, US-003, US-004, US-006
-Specs:: WT-006, WT-008, WT-009, WT-010, WT-012, WT-014, WT-015, WT-022, WT-023
-Description:: Implement `ListWorktrees()` parsing `git worktree list --porcelain`. Implement `AddWorktree()`, `RemoveWorktree()`, `IsDirty()`, `AheadBehind()`, `BranchExists()`. All functions return structured types with wrapped errors.
-
-== Phase 2: Core Commands
-
-Implement the non-interactive commands that operate on worktrees.
-
-* [x] TASK-004: Implement `wt create` command [parallel]
-+
-Components:: `cmd/create.go`, `internal/repo`, `internal/git`
-Stories:: US-002
-Specs:: WT-006, WT-007, WT-008, WT-009, WT-010, WT-011, WT-025
-Description:: Parse branch argument. Resolve repo and worktrees dir. Check for duplicate worktree. Check if branch exists (local/remote). Call `git.AddWorktree()` with appropriate flags. Output `__wt_cd:<path>` to stdout on success. Errors to stderr.
-
-* [x] TASK-005: Implement `wt remove` command (non-interactive path) [parallel]
-+
-Components:: `cmd/remove.go`, `internal/repo`, `internal/git`
-Stories:: US-003
-Specs:: WT-012, WT-014, WT-015, WT-016, WT-017
-Description:: Parse name argument and `--force` flag. Resolve worktree path. Check if worktree exists. Check dirty state; refuse if dirty without `--force`. Call `git.RemoveWorktree()`. Confirmation to stderr. The interactive path (no arg) is added in Phase 3.
-
-* [x] TASK-006: Implement `wt list` command [parallel]
-+
-Components:: `cmd/list.go`, `internal/repo`, `internal/git`
-Stories:: US-004
-Specs:: WT-018, WT-019
-Description:: List all worktrees. Format as a table showing branch, path, and main indicator. Output to stderr. Show "no additional worktrees" message when only the main worktree exists.
-
-* [x] TASK-007: Implement `wt switch` command [parallel]
-+
-Components:: `cmd/switch.go`, `internal/repo`, `internal/git`
-Stories:: US-005
-Specs:: WT-020, WT-021
-Description:: Parse name argument. Find matching worktree in list. Output `__wt_cd:<path>` to stdout. On not found: error to stderr with list of available worktrees.
-
-* [x] TASK-008: Implement `wt status` command [parallel]
-+
-Components:: `cmd/status.go`, `internal/repo`, `internal/git`
-Stories:: US-006
-Specs:: WT-022, WT-023
-Description:: List all worktrees. For each, call `IsDirty()` and `AheadBehind()`. Format as table with branch, clean/dirty indicator, ahead/behind counts, main indicator. Output to stderr.
-
-== Phase 3: Interactive TUI
-
-Implement the bubbletea fuzzy selector and wire it into commands.
-
-* [x] TASK-009: Implement TUI fuzzy selector [sequential]
+* [x] TASK-020: Add `IsMain` field to `tui.Entry` and update selector rendering [sequential]
 +
 Components:: `internal/tui/selector.go`
-Stories:: US-001, US-003
-Specs:: WT-001, WT-002, WT-003, WT-004, WT-005, WT-013
-Description:: Build a bubbletea model with a filterable list of worktree entries. Each entry shows branch name and relative path. Support fuzzy matching on branch name. Return selected worktree path on Enter, empty on Escape/Ctrl-C. Style with lipgloss.
+Stories:: US-001, US-013
+Specs:: WT-052
+Description:: Add `IsMain bool` field to the `Entry` struct. In the `View()` method, when rendering an entry where `IsMain` is true, apply a dimmed foreground style (using the existing `dimStyle` or a new `mainStyle` lipgloss style) to both the branch name and the path text. The main entry remains fully selectable -- the distinct style is for visual identification only. When the entry is the selected entry (`i == m.selected`), combine the selected cursor styling with the dimmed indicator so it is still clear the main entry is highlighted.
 
-* [x] TASK-010: Wire TUI into root command and remove command [sequential]
+== Phase 2: Command Layer Updates
+
+Update commands to include the main worktree in their output and remove the main-worktree filter.
+
+* [x] TASK-021: Include main worktree in interactive selector (`cmd/root.go`) [parallel]
 +
-Components:: `cmd/root.go`, `cmd/remove.go`
-Stories:: US-001, US-003
-Specs:: WT-001, WT-003, WT-004, WT-005, WT-013
-Description:: Root command (no subcommand): list worktrees, launch TUI, output `__wt_cd:<path>` on selection. Remove command (no arg): list worktrees, launch TUI in remove mode, proceed with removal of selected worktree.
+Components:: `cmd/root.go`
+Stories:: US-001, US-013
+Specs:: WT-001, WT-004, WT-053
+Description:: Remove the `if wt.Path == info.MainWorktree { continue }` filter in `runSelector`. Include the main worktree in the `entries` slice with `IsMain: true`. Change the "no worktrees" condition to check for zero linked worktrees (i.e., when the only worktree is main, still show the "No worktrees found" message since the user needs to create linked worktrees to use the selector meaningfully).
 
-== Phase 4: Shell Integration
-
-Implement the shell init command for cd integration.
-
-* [x] TASK-011: Implement `wt init` command with shell templates [parallel]
+* [x] TASK-022: Include main worktree in switch error hint and completions [parallel]
 +
-Components:: `cmd/init.go`, `internal/shell/shell.go`
-Stories:: US-008
-Specs:: WT-026, WT-027, WT-028
-Description:: Accept shell name argument (bash, zsh, fish). Output the appropriate shell function to stdout. The function captures `wt` binary stdout and runs `cd` when the `__wt_cd:` sentinel is detected. Validate shell argument, error on unsupported shell.
+Components:: `cmd/switch.go`, `cmd/completions.go`
+Stories:: US-005, US-011, US-013
+Specs:: WT-021, WT-044, WT-054, WT-055
+Description:: In `cmd/switch.go` `runSwitch()`, remove the `if wt.Path == info.MainWorktree { continue }` filter in the "not found" error hint so the main worktree branch is listed among available worktrees. In `cmd/completions.go`, update `completeWorktreeBranches()` to include all worktree branch names (including main). Keep `completeLinkedWorktreeBranches()` filtering out the main worktree (it is used by `wt remove`).
 
-== Phase 5: Branch Name Sanitization and Fuzzy Scoring
-
-Implement the two new standalone modules that other features depend on.
-
-* [x] TASK-012: Implement branch name sanitization module [parallel]
+* [x] TASK-023: Update `wt list` to always show table when worktrees exist [parallel]
 +
-Components:: `internal/names/names.go`
-Stories:: US-009
-Specs:: WT-029, WT-030, WT-031
-Description:: Create `internal/names/names.go` with `Sanitize(branch string) string`. Replace characters not matching `[a-zA-Z0-9-.]` with `-`. Collapse consecutive `-` into single `-`. Trim leading and trailing `-`. Include unit tests in `internal/names/names_test.go` covering: `feature-x` -> `feature-x`, `fix/bug-123` -> `fix-bug-123`, `feature//double` -> `feature-double`, `/leading-slash` -> `leading-slash`, `release/v2.0` -> `release-v2.0`.
+Components:: `cmd/list.go`
+Stories:: US-004, US-013
+Specs:: WT-018, WT-019
+Description:: The current `wt list` already includes the main worktree in the table when linked worktrees exist. However, when only the main worktree exists, it returns early with "No additional worktrees" before rendering any table. Keep this early-return behavior (the design specifies this message when no linked worktrees exist). No code change is needed here if the existing behavior matches the updated spec. Verify and confirm.
 
-* [x] TASK-013: Implement fuzzy scoring module [parallel]
+* [x] TASK-024: Update tests for main worktree inclusion [parallel]
 +
-Components:: `internal/fuzzy/fuzzy.go`
-Stories:: US-012
-Specs:: WT-048, WT-049, WT-050, WT-051
-Description:: Create `internal/fuzzy/fuzzy.go` with `Score(str, pattern string) Match` function and `Match` struct (`Score int`, `Matched bool`, `Positions []int`). Implement greedy forward-scan algorithm with scoring constants: `bonusFirstChar=16`, `bonusCamelCase=16`, `bonusSeparator=16`, `bonusAdjacent=8`, `penaltyLeadingGap=-3`, `penaltyGap=-1`. Case-insensitive matching. Return `{Score: 0, Matched: false, Positions: nil}` for non-matches. Include unit tests in `internal/fuzzy/fuzzy_test.go` covering: exact match, prefix match, separator boundary, camelCase boundary, adjacent bonus, gap penalty, non-match, empty pattern, and sort-order verification.
-
-== Phase 6: Enhanced Create and TUI
-
-Integrate sanitization and scoring into commands and selectors. Add interactive branch creation.
-
-* [x] TASK-014: Integrate branch name sanitization into create, remove, and switch commands [sequential]
-+
-Components:: `cmd/create.go`, `cmd/remove.go`, `cmd/switch.go`, `internal/names`
-Stories:: US-009
-Specs:: WT-032, WT-033, WT-034
-Description:: Update `create.go` to compute worktree directory path as `filepath.Join(worktreesDir, names.Sanitize(branch))` instead of using the branch name directly. Pass the original branch name to `git.AddWorktree()`. Update `remove.go` to walk upward from the removed worktree path toward the worktrees directory root and remove any empty parent directories after `git worktree remove`. Update `switch.go` to use sanitized names for path matching. Update `git.AddWorktree()` signature to accept a `base string` parameter (empty string means no base).
-
-* [x] TASK-015: Add branch listing functions to git module [parallel]
-+
-Components:: `internal/git/git.go`
-Stories:: US-010, US-011
-Specs:: WT-035, WT-037, WT-038, WT-043
-Description:: Add `ListLocalBranches() ([]string, error)` -- runs `git branch --format='%(refname:short)'`, returns sorted list. Add `ListRemoteBranches() ([]string, error)` -- runs `git branch -r --format='%(refname:short)'`, strips remote prefix, deduplicates, excludes HEAD entries, returns sorted list.
-
-* [x] TASK-016: Integrate fuzzy scoring into existing worktree selector [parallel]
-+
-Components:: `internal/tui/selector.go`, `internal/fuzzy`
-Stories:: US-012
-Specs:: WT-048, WT-049, WT-050, WT-051
-Description:: Replace the existing simple fuzzy matching in `selector.go` with `fuzzy.Score()`. When filter text is non-empty: score all entries, exclude non-matches, sort by descending score, highlight matched character positions using lipgloss. When filter text is empty: display all entries in original order without scoring.
-
-* [x] TASK-017: Implement interactive branch selector and wire into create command [sequential]
-+
-Components:: `internal/tui/branch_selector.go`, `cmd/create.go`, `internal/git`, `internal/names`, `internal/fuzzy`
-Stories:: US-010
-Specs:: WT-035, WT-036, WT-037, WT-038, WT-039, WT-040, WT-041, WT-042
-Description:: Create `internal/tui/branch_selector.go` with `BranchEntry` struct (`Name string`, `Source string`, `HasWorktree bool`) and `SelectBranch(entries []BranchEntry) (string, error)`. Render dimmed entries with `[worktree]` marker for branches that have worktrees; make them non-selectable. Use `fuzzy.Score()` for filtering and ranking. Update `create.go`: when invoked with no args, fetch branches via `git.ListLocalBranches()` + `git.ListRemoteBranches()`, build `BranchEntry` list, cross-reference with existing worktrees, launch `SelectBranch()`. Add `--local` and `--remote` flags to filter the branch list. Add `--base` flag for direct creation. When a non-existing branch is selected, launch a second `SelectBranch()` for base branch selection. Empty selection from either selector returns without creating.
-
-== Phase 7: Shell Completion
-
-Add shell tab-completion support.
-
-* [x] TASK-018: Implement `wt completion` command [parallel]
-+
-Components:: `cmd/completion.go`
-Stories:: US-011
-Specs:: WT-046, WT-047
-Description:: Create `cmd/completion.go` with a `completion` subcommand accepting a shell argument (`bash`, `zsh`, `fish`). Use Cobra's built-in `rootCmd.GenBashCompletionV2()`, `rootCmd.GenZshCompletion()`, `rootCmd.GenFishCompletion()` to output shell-specific completion scripts to stdout. Validate the shell argument; return an error listing supported shells for unsupported values.
-
-* [x] TASK-019: Add ValidArgsFunction to create, switch, and remove commands [parallel]
-+
-Components:: `cmd/create.go`, `cmd/switch.go`, `cmd/remove.go`, `internal/git`
-Stories:: US-011
-Specs:: WT-043, WT-044, WT-045
-Description:: Add `ValidArgsFunction` to `createCmd`: call `git.ListLocalBranches()` + `git.ListRemoteBranches()`, filter out branches that already have worktrees, return with `cobra.ShellCompDirectiveNoFileComp`. Add `ValidArgsFunction` to `switchCmd`: call `git.ListWorktrees()`, return worktree branch names. Add `ValidArgsFunction` to `removeCmd`: call `git.ListWorktrees()`, return linked (non-main) worktree branch names.
+Components:: `cmd/cmd_test.go`, `internal/tui/selector_test.go`
+Stories:: US-001, US-004, US-005, US-011, US-013
+Specs:: WT-001, WT-021, WT-044, WT-052, WT-053, WT-054, WT-055
+Description:: Update `TestRoot_NoWorktreesMessage` to verify the "no worktrees" message still appears when only the main worktree exists. Add a new test `TestRoot_IncludesMainWorktree` verifying that when linked worktrees exist, the selector entries include the main worktree. Update `TestList_WithWorktrees` to verify the main worktree appears in the list output. Add a new test for `tui.Entry.IsMain` rendering in selector. Update `TestSwitch_NotFound` or equivalent to verify the error hint includes the main worktree. Update completion tests to verify `completeWorktreeBranches()` includes the main branch and `completeLinkedWorktreeBranches()` excludes it.
 
 == Traceability
 
@@ -180,50 +62,22 @@ Description:: Add `ValidArgsFunction` to `createCmd`: call `git.ListLocalBranche
 | Story | Spec IDs | Tasks
 
 | US-001: Interactive Worktree Selection
-| WT-001, WT-002, WT-003, WT-004, WT-005
-| TASK-009, TASK-010
-
-| US-002: Create Worktree
-| WT-006, WT-007, WT-008, WT-009, WT-010, WT-011
-| TASK-003, TASK-004
-
-| US-003: Remove Worktree
-| WT-012, WT-013, WT-014, WT-015, WT-016, WT-017
-| TASK-003, TASK-005, TASK-009, TASK-010
+| WT-001, WT-052, WT-053
+| TASK-020, TASK-021
 
 | US-004: List Worktrees
 | WT-018, WT-019
-| TASK-003, TASK-006
+| TASK-023
 
 | US-005: Switch to Worktree
-| WT-020, WT-021
-| TASK-007
-
-| US-006: Worktree Status Overview
-| WT-022, WT-023
-| TASK-003, TASK-008
-
-| US-007: Worktree Directory Convention
-| WT-007, WT-024, WT-025
-| TASK-002, TASK-004
-
-| US-008: Shell Integration
-| WT-026, WT-027, WT-028
-| TASK-011
-
-| US-009: Safe Worktree Directory Names
-| WT-029, WT-030, WT-031, WT-032, WT-033, WT-034
-| TASK-012, TASK-014
-
-| US-010: Interactive Branch Selection
-| WT-035, WT-036, WT-037, WT-038, WT-039, WT-040, WT-041, WT-042
-| TASK-015, TASK-017
+| WT-021, WT-054
+| TASK-022
 
 | US-011: Shell Completion
-| WT-043, WT-044, WT-045, WT-046, WT-047
-| TASK-015, TASK-018, TASK-019
+| WT-044, WT-055
+| TASK-022
 
-| US-012: Ranked Fuzzy Matching
-| WT-048, WT-049, WT-050, WT-051
-| TASK-013, TASK-016
+| US-013: Main Worktree Visibility
+| WT-001, WT-018, WT-021, WT-044, WT-052, WT-053, WT-054, WT-055
+| TASK-020, TASK-021, TASK-022, TASK-023, TASK-024
 |===

--- a/docs/features/worktree-management/user-stories.adoc
+++ b/docs/features/worktree-management/user-stories.adoc
@@ -1,6 +1,6 @@
 = User Stories: Worktree Management
-:version: 1.1.0
-:last-updated: 2026-02-26
+:version: 1.2.0
+:last-updated: 2026-02-27
 :feature: worktree-management
 :toc:
 
@@ -11,10 +11,11 @@ so that I can quickly switch to the worktree I need without remembering its exac
 
 Acceptance Criteria:
 
-* [ ] When the user invokes `wt` with no arguments, the system shall display an interactive fuzzy-search selector listing all existing worktrees for the current repository.
+* [ ] When the user invokes `wt` with no arguments, the system shall display an interactive fuzzy-search selector listing all existing worktrees for the current repository, including the main worktree.
 * [ ] The system shall display each worktree entry with its branch name and relative path.
+* [ ] While the main worktree entry is displayed in the selector, the system shall render it with a visually distinct style to differentiate it from linked worktrees.
 * [ ] When the user selects a worktree from the selector, the system shall output a `cd` command targeting the selected worktree directory.
-* [ ] If no worktrees exist for the current repository, then the system shall display a message indicating no worktrees are available and suggest the `wt create` command.
+* [ ] If only the main worktree exists and no linked worktrees have been created, then the system shall display a message indicating no worktrees are available and suggest the `wt create` command.
 * [ ] If the user cancels the selector (e.g., pressing Escape), then the system shall exit without output.
 
 == US-002: Create Worktree
@@ -51,9 +52,9 @@ so that I can understand what branches I have checked out and where.
 
 Acceptance Criteria:
 
-* [ ] When the user invokes `wt list`, the system shall display all worktrees for the current repository.
+* [ ] When the user invokes `wt list`, the system shall display all worktrees for the current repository, including the main worktree.
 * [ ] The system shall display each worktree with its branch name, path, and whether it is the main worktree.
-* [ ] If no worktrees exist beyond the main worktree, then the system shall display a message indicating no additional worktrees exist.
+* [ ] If only the main worktree exists and no linked worktrees have been created, then the system shall display a message indicating no additional worktrees exist and suggest the `wt create` command.
 
 == US-005: Switch to Worktree
 As a developer,
@@ -63,7 +64,8 @@ so that I can navigate quickly when I already know the worktree name.
 Acceptance Criteria:
 
 * [ ] When the user invokes `wt switch <name>`, the system shall output a `cd` command targeting the specified worktree directory.
-* [ ] If the specified worktree does not exist, then the system shall display an error message and list available worktrees.
+* [ ] The system shall support switching to the main worktree by its branch name.
+* [ ] If the specified worktree does not exist, then the system shall display an error message and list all available worktrees, including the main worktree.
 
 == US-006: Worktree Status Overview
 As a developer,
@@ -137,7 +139,7 @@ so that I can use the CLI efficiently without having to type or remember full na
 Acceptance Criteria:
 
 * [ ] When the user presses Tab after `wt create`, the system shall suggest local and remote branch names, excluding branches that already have a worktree.
-* [ ] When the user presses Tab after `wt switch`, the system shall suggest existing worktree branch names.
+* [ ] When the user presses Tab after `wt switch`, the system shall suggest all existing worktree branch names, including the main worktree branch.
 * [ ] When the user presses Tab after `wt remove`, the system shall suggest existing linked worktree branch names.
 * [ ] The system shall provide a `wt completion <shell>` command that outputs shell-specific completion scripts for Bash, Zsh, and Fish.
 * [ ] If the user invokes `wt completion` with an unsupported shell, then the system shall display an error listing the supported shells.
@@ -154,3 +156,16 @@ Acceptance Criteria:
 * [ ] The system shall sort filtered results by descending match score so that the best matches appear at the top.
 * [ ] The system shall highlight the matched characters in each result entry in the interactive selector.
 * [ ] When no filter text is entered, the system shall display all entries in their original order without scoring.
+
+== US-013: Main Worktree Visibility
+As a developer,
+I want the main repository worktree to appear in all worktree listings and the interactive selector,
+so that I can navigate back to the main worktree using the same workflow I use for linked worktrees.
+
+Acceptance Criteria:
+
+* [ ] The system shall include the main worktree in the interactive selector, the `wt list` output, the `wt switch` error hint, and the `wt switch` tab completions.
+* [ ] While the main worktree is displayed in the interactive selector, the system shall render it with a visually distinct style so that the user can differentiate it from linked worktrees.
+* [ ] While the main worktree is displayed in the `wt list` output, the system shall mark it with a `*` in the MAIN column.
+* [ ] When the user selects the main worktree from the interactive selector, the system shall output a `cd` command targeting the main worktree directory.
+* [ ] When the user invokes `wt remove` interactively or via tab completion, the system shall exclude the main worktree from the available choices.

--- a/internal/tui/selector.go
+++ b/internal/tui/selector.go
@@ -17,6 +17,7 @@ type Entry struct {
 	Branch string
 	Path   string
 	Rel    string
+	IsMain bool
 }
 
 // filteredEntry holds an Entry along with its fuzzy match result for rendering.
@@ -56,6 +57,7 @@ type model struct {
 var (
 	selectedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Bold(true)
 	dimStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	mainStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Italic(true)
 	promptStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 	highlightStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("220")).Bold(true)
 )
@@ -157,6 +159,13 @@ func (m model) View() string {
 		var branchText string
 		pathText := dimStyle.Render(fe.Rel)
 
+		// Use distinct style for main worktree entries
+		baseStyle := lipgloss.NewStyle()
+		if fe.IsMain {
+			baseStyle = mainStyle
+			pathText = mainStyle.Render(fe.Rel)
+		}
+
 		if i == m.selected {
 			cursor = selectedStyle.Render("> ")
 			if hasQuery && fe.match.Positions != nil {
@@ -167,9 +176,13 @@ func (m model) View() string {
 			b.WriteString(fmt.Sprintf("%s%s  %s\n", cursor, branchText, pathText))
 		} else {
 			if hasQuery && fe.match.Positions != nil {
-				branchText = highlightBranch(fe.Branch, fe.match.Positions, lipgloss.NewStyle(), highlightStyle)
+				branchText = highlightBranch(fe.Branch, fe.match.Positions, baseStyle, highlightStyle)
 			} else {
-				branchText = fe.Branch
+				if fe.IsMain {
+					branchText = mainStyle.Render(fe.Branch)
+				} else {
+					branchText = fe.Branch
+				}
 			}
 			b.WriteString(fmt.Sprintf("  %s  %s\n", branchText, pathText))
 		}


### PR DESCRIPTION
## Summary

- **Include main worktree in all CLI surfaces**: interactive fuzzy selector, `wt switch` error hints, `wt list` output, and shell tab completions — previously the main worktree was filtered out everywhere
- **Visually distinguish main worktree**: in the interactive selector, the main worktree entry renders with a dimmed style via lipgloss `IsMain` flag on `tui.Entry`
- **Exclude main from remove only**: `wt remove` interactive selector and tab completions correctly exclude the main worktree (not removable)

## Changes

- `cmd/root.go` — Remove main worktree filter; include it in selector entries with `IsMain: true`
- `cmd/switch.go` — Allow switching to main worktree; show main in "not found" error hint
- `cmd/completions.go` — `completeWorktreeBranches()` returns all branches (including main); `completeLinkedWorktreeBranches()` excludes main (for remove)
- `internal/tui/selector.go` + `selector_test.go` — Add `IsMain` field to `Entry`; render with distinct style
- `cmd/cmd_test.go` — New/updated tests for main worktree inclusion across commands
- `docs/features/worktree-management/` — Updated spec (v1.2.0), stories (v1.2.0), design (v2.1.0), tasks (v3.0.0) with new requirements WT-052 through WT-055

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Main worktree now appears in the interactive selector and list output with visual distinction
  * Support for switching to the main worktree by branch name
  * Main worktree included in available worktree listings and error messages
  * Tab completion now suggests the main worktree alongside linked worktrees
  * Remove command excludes the main worktree from interactive choices

* **Documentation**
  * Spec version updated to 1.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->